### PR TITLE
Optimize the code and simplify the logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proxyverse",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/background.ts
+++ b/src/background.ts
@@ -11,3 +11,4 @@ async function initIndicator() {
 
 
 initIndicator().catch(console.error)
+chrome.proxy.onProxyError.addListener(console.warn)

--- a/src/components/ProfileConfig.vue
+++ b/src/components/ProfileConfig.vue
@@ -151,7 +151,7 @@ const loadProfile = async (profileID: string) => {
 
   profileFirstLoaded = true
   Object.assign(profileConfig, profile)
-  if (profileConfig.proxyRules.ftp || profileConfig.proxyRules.http || profileConfig.proxyRules.https) {
+  if (profileConfig.proxyType == 'proxy' && (profileConfig.proxyRules.ftp || profileConfig.proxyRules.http || profileConfig.proxyRules.https)) {
     showAdvanceConfig.value = true
   }
 }
@@ -168,7 +168,7 @@ onMounted(() => {
         <a-color-picker v-model="profileConfig.color" disabledAlpha showPreset format="hex" />
         <a-typography-text editable :defaultEditing="newProfileMode" v-model:editText="profileConfig.profileName">{{
           profileConfig.profileName
-          }}</a-typography-text>
+        }}</a-typography-text>
       </a-space>
     </template>
     <template #extra>

--- a/src/models/indicator.ts
+++ b/src/models/indicator.ts
@@ -1,18 +1,22 @@
+import { SystemProfile } from "./profile";
 import { ProxySetting } from "./proxy";
 
 export async function setIndicator(proxy: ProxySetting) {
   const curMode = proxy.setting.value?.mode
+  let profile = proxy.activeProfile
 
+  // overide profile
   switch (curMode) {
     case 'system':
-      return await setBadge('', '#000000')
-
+      profile = SystemProfile.SYSTEM
+      break
     case 'direct':
-      return await setBadge('DIRECT', '#7ad39e')
+      profile = SystemProfile.DIRECT
+      break
   }
 
-  if (proxy.activeProfile) {
-    await setBadge(proxy.activeProfile.profileName, proxy.activeProfile.color)
+  if (profile) {
+    await setBadge(profile.profileName, profile.color)
   }
 }
 

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -9,7 +9,13 @@ export type ProxyServer = (chrome.proxy.ProxyServer & {
   scheme: 'direct' | 'http' | 'https' | 'socks4' | 'socks5'
 })
 
-type ProxyConfigSimple = {
+type ProxyConfigMeta = {
+  profileID: string,
+  color: string,
+  profileName: string,
+}
+
+export type ProxyConfigSimple = ProxyConfigMeta & {
   proxyType: 'proxy' | 'pac',
   proxyRules: {
     default: ProxyServer,
@@ -21,12 +27,27 @@ type ProxyConfigSimple = {
   pacScript: chrome.proxy.PacScript
 }
 
-export type ProfileConfig = {
-  profileID: string,
-  color: string,
-  profileName: string,
+export type ProxyConfigPreset = ProxyConfigMeta & {
+  proxyType: 'system' | 'direct'
+}
 
-} & (ProxyConfigSimple)
+export type ProfileConfig = ProxyConfigSimple | ProxyConfigPreset
+
+
+export const SystemProfile: Record<string, ProfileConfig> = {
+  DIRECT: {
+    profileID: '367DEDBC-6750-4454-8321-4E4B088E20B1',
+    color: '#7ad39e',
+    profileName: 'DIRECT',
+    proxyType: 'direct'
+  },
+  SYSTEM: {
+    profileID: '4FDEF36F-F389-4AF3-9BBC-B2E01B3B09E6',
+    color: '#0000',
+    profileName: '', // no name needed for `system`
+    proxyType: 'system'
+  },
+}
 
 
 const keyProfileStorage = 'profiles'

--- a/src/models/proxy/index.ts
+++ b/src/models/proxy/index.ts
@@ -1,8 +1,6 @@
-import { ProfileConfig } from "../profile"
+import { ProfileConfig, SystemProfile } from "../profile"
 import { get, set } from "../store"
-import { SimpleProxyValue, genSimpleProxyCfg } from "./proxyRules"
-
-export type ProxyValue = SimpleProxyValue
+import { genSimpleProxyCfg } from "./proxyRules"
 
 export type ProxySetting = {
   activeProfile?: ProfileConfig
@@ -20,6 +18,15 @@ async function wrapProxySetting(setting: chrome.types.ChromeSettingGetResultDeta
     ret.activeProfile = await get<ProfileConfig>(keyActiveProfile) || undefined
   }
 
+  switch (setting.value?.mode) {
+    case 'system':
+      ret.activeProfile = SystemProfile.SYSTEM
+      break
+    case 'direct':
+      ret.activeProfile = SystemProfile.DIRECT
+      break
+  }
+
   return ret
 }
 
@@ -35,30 +42,32 @@ export function onCurrentProxySettingChanged(cb: (setting: ProxySetting) => void
   })
 }
 
-export async function setProxy(val: ProxyValue) {
-  switch (val) {
-    case 'system':
-    case 'direct':
-      await defaultSetProxy(genSimpleProxyCfg(val), val)
-      return
-  }
-
+export async function setProxy(val: ProfileConfig) {
   switch (val.proxyType) {
+    case 'system':
+      await defaultClearProxy()
+      break
+
+    case 'direct':
     case 'proxy':
     case 'pac':
-      await defaultSetProxy(genSimpleProxyCfg(val), val)
-      return
+      await defaultSetProxy(genSimpleProxyCfg(val))
+      break
   }
+
+  await set<ProfileConfig>(keyActiveProfile, val)
 }
 
 
-async function defaultSetProxy(cfg: chrome.proxy.ProxyConfig, meta: ProxyValue) {
+async function defaultSetProxy(cfg: chrome.proxy.ProxyConfig) {
   await chrome.proxy.settings.set({
     value: cfg,
     scope: "regular",
   })
 
-  if (typeof meta != 'string' && meta.profileID) {
-    await set<ProfileConfig>(keyActiveProfile, meta)
-  }
+
+}
+
+async function defaultClearProxy() {
+  await chrome.proxy.settings.clear({ scope: 'regular' })
 }

--- a/src/models/proxy/index.ts
+++ b/src/models/proxy/index.ts
@@ -64,8 +64,6 @@ async function defaultSetProxy(cfg: chrome.proxy.ProxyConfig) {
     value: cfg,
     scope: "regular",
   })
-
-
 }
 
 async function defaultClearProxy() {

--- a/src/pages/PopupPage.vue
+++ b/src/pages/PopupPage.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { type RouteLocationRaw, useRouter } from 'vue-router';
 import ThemeSwitcher from '../components/controls/ThemeSwitcher.vue';
-import { ProfilesStorage, listProfiles } from '../models/profile';
+import { ProfilesStorage, listProfiles, SystemProfile, ProfileConfig } from '../models/profile';
 import { onMounted, ref, toRaw } from 'vue';
-import { type ProxyValue, setProxy, getCurrentProxySetting } from '../models/proxy';
+import { setProxy, getCurrentProxySetting } from '../models/proxy';
 import { Message } from '@arco-design/web-vue';
 import { transify } from '../models/i18n';
 
@@ -14,14 +14,6 @@ const selectedKeys = defineModel<string[]>()
 onMounted(async () => {
   profiles.value = await listProfiles();
   const proxy = await getCurrentProxySetting()
-  const curMode = proxy.setting.value?.mode
-  switch (curMode) {
-    case 'system':
-    case 'direct':
-      selectedKeys.value = [curMode]
-      return
-  }
-
   const profileID = proxy.activeProfile?.profileID
   if (profileID) {
     selectedKeys.value = [profileID]
@@ -35,7 +27,7 @@ const jumpTo = (to: RouteLocationRaw) => {
 }
 
 // actions
-const setProxyByProfile = async (val: ProxyValue) => {
+const setProxyByProfile = async (val: ProfileConfig) => {
   try {
     console.log(toRaw(val))
     await setProxy(toRaw(val))
@@ -57,13 +49,15 @@ const setProxyByProfile = async (val: ProxyValue) => {
     </a-layout-header>
     <a-layout-content class="profiles">
       <a-menu :selected-keys="selectedKeys">
-        <a-menu-item key="direct" @click.prevent="() => setProxyByProfile('direct')"
-          style="--indicator-color: rgb(var(--success-3))">
+        <a-menu-item :key="SystemProfile.DIRECT.profileID"
+          @click.prevent="() => setProxyByProfile(SystemProfile.DIRECT)"
+          :style="{ '--indicator-color': SystemProfile.DIRECT.color }">
           <template #icon><icon-swap /></template>
           {{ $t("mode_direct") }}
         </a-menu-item>
-        <a-menu-item key="system" @click.prevent="() => setProxyByProfile('system')"
-          style="--indicator-color: var(--color-border-4)">
+        <a-menu-item :key="SystemProfile.SYSTEM.profileID"
+          @click.prevent="() => setProxyByProfile(SystemProfile.SYSTEM)"
+          :style="{ '--indicator-color': SystemProfile.SYSTEM.color }">
           <template #icon><icon-desktop /></template>
           {{ $t("mode_system") }}
         </a-menu-item>

--- a/tests/models/proxy/proxyRules.test.ts
+++ b/tests/models/proxy/proxyRules.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from '@jest/globals';
 import { genSimpleProxyCfg } from "@/models/proxy/proxyRules.ts"
-import { ProfileConfig } from '@/models/profile';
+import { ProfileConfig, SystemProfile } from '@/models/profile';
 
 describe('testing genSimpleProxyCfg for direct and system', () => {
   test('proxy config mode', () => {
-    const cfg = genSimpleProxyCfg('direct')
+    const cfg = genSimpleProxyCfg(SystemProfile.DIRECT)
     expect(cfg.mode).toBe('direct');
   });
 });


### PR DESCRIPTION
1. Simplify the type definition 
2. Change the behaviour of `system` mode to clear the proxy settings, allowing other extensions to modify the proxy setting.