### PR TITLE
UX improvement and close #28

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -107,8 +107,17 @@
   "config_section_auto_switch_type_url": {
     "message": "URL"
   },
+  "config_section_auto_switch_type_url_malformed": {
+    "message": "Invalid URL"
+  },
+  "config_section_auto_switch_type_url_malformed_chrome": {
+    "message": "For security reasons, Chrome does not support path matching in HTTPS URLs. Learn more at https://issues.chromium.org/40083832"
+  },
   "config_section_auto_switch_type_cidr": {
-    "message": "IP/CIDR"
+    "message": "CIDR"
+  },
+  "config_section_auto_switch_type_cidr_malformed": {
+    "message": "Invalid CIDR. Please use the format like `192.168.1.1/24` or `2001:db8::/32`"
   },
   "config_section_auto_switch_type_disabled": {
     "message": "Temporarily Skip"
@@ -200,7 +209,6 @@
   "preferences_feedback_n_profiles_being_imported": {
     "message": "$1 profiles have been imported"
   },
-
 
   "form_is_required": {
     "message": "$1 is required"

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -50,7 +50,17 @@ export type SimpleProxyServer = chrome.proxy.ProxyServer;
 export type PacScript = chrome.proxy.PacScript;
 export type ProxyRules = chrome.proxy.ProxyRules;
 
+export enum BrowserFlavor {
+  Unknown = "unknown",
+  Web = "web", // now only for local dev purpose
+  Chrome = "chrome",
+}
+
 export abstract class BaseAdapter {
+  get flavor(): BrowserFlavor {
+    return BrowserFlavor.Unknown;
+  }
+
   // local storage
   abstract set<T>(key: string, val: T): Promise<void>;
   abstract get<T>(key: string): Promise<T | undefined>;

--- a/src/adapters/chrome.ts
+++ b/src/adapters/chrome.ts
@@ -3,6 +3,7 @@
 import {
   BaseAdapter,
   BlockingResponse,
+  BrowserFlavor,
   ProxyConfig,
   ProxyErrorDetails,
   ProxySettingResultDetails,
@@ -12,6 +13,10 @@ import {
 } from "./base";
 
 export class Chrome extends BaseAdapter {
+  get flavor() {
+    return BrowserFlavor.Chrome;
+  }
+
   async set<T>(key: string, val: T): Promise<void> {
     return await chrome.storage.local.set({
       [key]: val,

--- a/src/adapters/web.ts
+++ b/src/adapters/web.ts
@@ -3,6 +3,7 @@
 import {
   BaseAdapter,
   BlockingResponse,
+  BrowserFlavor,
   ProxyConfig,
   ProxyErrorDetails,
   ProxySettingResultDetails,
@@ -20,6 +21,10 @@ const _i18n: {
 } = i18nData;
 
 export class WebBrowser extends BaseAdapter {
+  get flavor() {
+    return BrowserFlavor.Web;
+  }
+
   async set<T>(key: string, val: T): Promise<void> {
     localStorage.setItem(key, JSON.stringify(val));
   }

--- a/src/components/configs/AutoSwitchInput.vue
+++ b/src/components/configs/AutoSwitchInput.vue
@@ -11,6 +11,7 @@ import {
 } from "@/services/profile";
 import ProfileSelector from "./ProfileSelector.vue";
 import { BrowserFlavor } from "@/adapters/base";
+import { isValidCIDR } from "ipaddr.js";
 
 const props = defineProps<{
   currentProfileID?: string;
@@ -133,11 +134,16 @@ const getConditionInputRule = (type: AutoSwitchType): FieldRule<string> => {
     case "cidr":
       return {
         required: true,
-        message: Host.getMessage(
-          "config_section_auto_switch_type_cidr_malformed"
-        ),
-        match:
-          /^((\d{1,3}\.){3}\d{1,3}\/\d{1,2}|([a-fA-F0-9:]+:+)+[a-fA-F0-9]+\/\d{1,3})$/,
+        validator: (value, cb) => {
+          if (!value || !isValidCIDR(value)) {
+            cb(
+              Host.getMessage("config_section_auto_switch_type_cidr_malformed")
+            );
+            return;
+          }
+
+          cb();
+        },
       };
 
     default:

--- a/src/components/configs/ProfileSelector.vue
+++ b/src/components/configs/ProfileSelector.vue
@@ -13,7 +13,10 @@ const props = defineProps<{
   disabled?: boolean;
 }>();
 
-const profileID = defineModel<string>();
+const profileID = defineModel<string>({
+  required: true,
+});
+
 const userProfiles = ref<ProxyProfile[]>([]);
 const systemProfiles = ref<ProxyProfile[]>([]);
 const selectedProfile = computed<ProxyProfile | undefined>({
@@ -28,7 +31,9 @@ const selectedProfile = computed<ProxyProfile | undefined>({
     );
   },
   set: (value) => {
-    profileID.value = value?.profileID;
+    if (value) {
+      profileID.value = value.profileID;
+    }
   },
 });
 
@@ -96,6 +101,7 @@ onBeforeMount(() => {
         </a-doption>
         <a-doption
           :value="SystemProfile.SYSTEM.profileID"
+          :disabled="!!props.currentProfileID"
           :style="{ '--indicator-color': SystemProfile.SYSTEM.color }"
         >
           <template #icon><icon-desktop /></template>

--- a/src/components/configs/ProxyServerInput.vue
+++ b/src/components/configs/ProxyServerInput.vue
@@ -115,7 +115,7 @@ const onClearAuth = () => {
         <a-select
           :options="options"
           :style="{ width: proxyType == optionDefault ? 'auto' : '7em' }"
-          v-model="proxyType"
+          v-model="proxyType as string"
         />
 
         <template v-if="proxyType == optionDirect"></template>


### PR DESCRIPTION
This pull request includes several changes across different files to improve validation messages, introduce a new `BrowserFlavor` enum, and enhance form handling in the `AutoSwitchInput.vue` component. The most important changes are summarized below.

### Validation Messages Enhancements:
* [`public/_locales/en/messages.json`](diffhunk://#diff-d5a5a9eb2f0d2c86006fb09bf07a55d4af6227b1dba33edb6c36a78871f1641fR110-R120): Added new validation messages for malformed URLs and CIDR formats, and updated existing messages for better clarity. [[1]](diffhunk://#diff-d5a5a9eb2f0d2c86006fb09bf07a55d4af6227b1dba33edb6c36a78871f1641fR110-R120) [[2]](diffhunk://#diff-d5a5a9eb2f0d2c86006fb09bf07a55d4af6227b1dba33edb6c36a78871f1641fL204)

### Introduction of `BrowserFlavor` Enum:
* [`src/adapters/base.ts`](diffhunk://#diff-966fa1463238e427403d5db788db050d394e0232ad8b3edeb6f06356317447bcR53-R63): Introduced the `BrowserFlavor` enum and added a `flavor` getter to the `BaseAdapter` class.
* [`src/adapters/chrome.ts`](diffhunk://#diff-26fec76711364f14000c2a5f2ac70f3a982e02037f8e59fc18fcdb9334f1d8f8R6): Updated the `Chrome` class to override the `flavor` getter with `BrowserFlavor.Chrome`. [[1]](diffhunk://#diff-26fec76711364f14000c2a5f2ac70f3a982e02037f8e59fc18fcdb9334f1d8f8R6) [[2]](diffhunk://#diff-26fec76711364f14000c2a5f2ac70f3a982e02037f8e59fc18fcdb9334f1d8f8R16-R19)
* [`src/adapters/web.ts`](diffhunk://#diff-772c318701a45e0061cf492c96a79d985ab6dd45769681d265fb6b714c5e3e7eR6): Updated the `WebBrowser` class to override the `flavor` getter with `BrowserFlavor.Web`. [[1]](diffhunk://#diff-772c318701a45e0061cf492c96a79d985ab6dd45769681d265fb6b714c5e3e7eR6) [[2]](diffhunk://#diff-772c318701a45e0061cf492c96a79d985ab6dd45769681d265fb6b714c5e3e7eR24-R27)

### Form Handling in `AutoSwitchInput.vue`:
* [`src/components/configs/AutoSwitchInput.vue`](diffhunk://#diff-774798f236e14c9904d714491522a53c58e3fa81acf97734531f25359acacda6R95-R215): Enhanced form validation by adding a `getConditionInputRule` function to validate URL and CIDR inputs based on the `AutoSwitchType`. [[1]](diffhunk://#diff-774798f236e14c9904d714491522a53c58e3fa81acf97734531f25359acacda6R95-R215) [[2]](diffhunk://#diff-774798f236e14c9904d714491522a53c58e3fa81acf97734531f25359acacda6R273-R286)

### Other Component Enhancements:
* [`src/components/configs/ProfileSelector.vue`](diffhunk://#diff-6ccd6ed1d16979a8dd8d3f7ef65f76fdb1dea7c96dbe8e77b8c712b256c7119bL16-R19): Added a required constraint to the `profileID` model and updated the handling of the `selectedProfile` computed property. [[1]](diffhunk://#diff-6ccd6ed1d16979a8dd8d3f7ef65f76fdb1dea7c96dbe8e77b8c712b256c7119bL16-R19) [[2]](diffhunk://#diff-6ccd6ed1d16979a8dd8d3f7ef65f76fdb1dea7c96dbe8e77b8c712b256c7119bL31-R36) [[3]](diffhunk://#diff-6ccd6ed1d16979a8dd8d3f7ef65f76fdb1dea7c96dbe8e77b8c712b256c7119bR104)
* [`src/components/configs/ProxyServerInput.vue`](diffhunk://#diff-733a74a8945bbc990bcbfd4e744dae5f06a2d85f0d7539672ee49e2e54ee95e8L118-R118): Ensured the `proxyType` is treated as a string in the `v-model` binding.